### PR TITLE
The cover image url is not prefixed

### DIFF
--- a/src/layouts/MainHeader/MainHeader.jsx
+++ b/src/layouts/MainHeader/MainHeader.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import { withPrefix } from "gatsby-link";
 import "./MainHeader.css";
 
 class MainHeader extends React.Component {
@@ -12,7 +13,7 @@ class MainHeader extends React.Component {
 
     const getStyle = () => {
       if (cover) {
-        return { backgroundImage: `url("${cover}")` };
+        return { backgroundImage: `url("${withPrefix(cover)}")` };
       }
       return null;
     };


### PR DESCRIPTION
The cover image URL should be prefixed when deployed to a site other than the root domain, e.g. http://example.github.io/my-gatsby-site/